### PR TITLE
Add usb detection / serial communication to app

### DIFF
--- a/HiveAR/app/build.gradle
+++ b/HiveAR/app/build.gradle
@@ -29,12 +29,11 @@ android {
 }
 
 dependencies {
-
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.material:material:1.2.1'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'androidx.navigation:navigation-fragment:2.2.2'
-    implementation 'androidx.navigation:navigation-ui:2.2.2'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'com.github.felHR85:UsbSerial:6.1.0'
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/HiveAR/app/src/main/AndroidManifest.xml
+++ b/HiveAR/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.swarmus.hivear">
 
+    <uses-feature android:name="android.hardware.usb.host" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -9,6 +11,11 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.HiveAR">
+        <receiver
+            android:name=".UsbReceiver"
+            android:enabled="true"
+            android:exported="true" />
+
         <activity
             android:name=".MainActivity"
             android:label="@string/title_activity_main"
@@ -21,7 +28,19 @@
         <activity
             android:name=".ARActivity"
             android:parentActivityName=".MainActivity"
-            android:theme="@style/Theme.HiveAR.NoActionBar"/>
+            android:theme="@style/Theme.HiveAR.NoActionBar" />
+        <activity
+            android:name=".DeviceActivity"
+            android:parentActivityName=".MainActivity"
+            android:theme="@style/Theme.HiveAR.NoActionBar" >
+            <intent-filter>
+                <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
+                <action android:name="android.hardware.usb.action.USB_DEVICE_DETACHED" />
+            </intent-filter>
+            <meta-data
+                android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
+                android:resource="@xml/device_filter" />
+        </activity>
     </application>
 
 </manifest>

--- a/HiveAR/app/src/main/java/com/swarmus/hivear/DeviceActivity.java
+++ b/HiveAR/app/src/main/java/com/swarmus/hivear/DeviceActivity.java
@@ -65,41 +65,33 @@ public class DeviceActivity extends AppCompatActivity {
         Button clearDataButton = findViewById(R.id.clearSerialDataButton);
         clearDataButton.setOnClickListener(v -> deviceSerialData.setText(""));
 
-        Button upButton = findViewById(R.id.upButton);
-        upButton.setOnClickListener(v -> {
-            if (serial != null) {
-                byte[] data = ("Up"+'\n').getBytes();
-                serial.write(data);
-            }
-        });
-        Button leftButton = findViewById(R.id.leftButton);
-        leftButton.setOnClickListener(v -> {
-            if (serial != null) {
-                byte[] data = ("Left"+'\n').getBytes();
-                serial.write(data);
-            }
-        });
-        Button rightButton = findViewById(R.id.rightButton);
-        rightButton.setOnClickListener(v -> {
-            if (serial != null) {
-                byte[] data = ("Right"+'\n').getBytes();
-                serial.write(data);
-            }
-        });
-        Button downButton = findViewById(R.id.downButton);
-        downButton.setOnClickListener(v -> {
-            if (serial != null) {
-                byte[] data = ("Down"+'\n').getBytes();
-                serial.write(data);
-            }
-        });
-        Button stopButton = findViewById(R.id.stopButton);
-        stopButton.setOnClickListener(v -> {
-            if (serial != null) {
-                byte[] data = ("Stop"+'\n').getBytes();
-                serial.write(data);
-            }
-        });
+        if (serial != null) {
+            Button upButton = findViewById(R.id.upButton);
+            upButton.setOnClickListener(v -> {
+                    byte[] data = ("Up"+'\n').getBytes();
+                    serial.write(data);
+            });
+            Button leftButton = findViewById(R.id.leftButton);
+            leftButton.setOnClickListener(v -> {
+                    byte[] data = ("Left"+'\n').getBytes();
+                    serial.write(data);
+            });
+            Button rightButton = findViewById(R.id.rightButton);
+            rightButton.setOnClickListener(v -> {
+                    byte[] data = ("Right"+'\n').getBytes();
+                    serial.write(data);
+            });
+            Button downButton = findViewById(R.id.downButton);
+            downButton.setOnClickListener(v -> {
+                    byte[] data = ("Down"+'\n').getBytes();
+                    serial.write(data);
+            });
+            Button stopButton = findViewById(R.id.stopButton);
+            stopButton.setOnClickListener(v -> {
+                    byte[] data = ("Stop"+'\n').getBytes();
+                    serial.write(data);
+            });
+        }
 
         usbReceiver = new UsbReceiver(this);
         IntentFilter usbDeviceFilter = new IntentFilter();

--- a/HiveAR/app/src/main/java/com/swarmus/hivear/DeviceActivity.java
+++ b/HiveAR/app/src/main/java/com/swarmus/hivear/DeviceActivity.java
@@ -29,15 +29,15 @@ import java.util.HashMap;
 import java.util.Iterator;
 
 public class DeviceActivity extends AppCompatActivity {
-    PendingIntent permissionIntent;
-    TextView deviceListingText;
-    TextView deviceSerialData;
-    TextView currentDevice;
-    UsbDevice device;
-    UsbManager manager;
-    UsbDeviceConnection connection;
-    UsbSerialDevice serial;
-    UsbReceiver usbReceiver;
+    private PendingIntent permissionIntent;
+    private TextView deviceListingText;
+    private TextView deviceSerialData;
+    private TextView currentDevice;
+    private UsbDevice device;
+    private UsbManager manager;
+    private UsbDeviceConnection connection;
+    private UsbSerialDevice serial;
+    private UsbReceiver usbReceiver;
 
     private static final String TAG = MainActivity.class.getSimpleName();
     private static final String ACTION_USE_PERMISSION = "com.swarmus.usbcomm.USB_PERMISSION";

--- a/HiveAR/app/src/main/java/com/swarmus/hivear/DeviceActivity.java
+++ b/HiveAR/app/src/main/java/com/swarmus/hivear/DeviceActivity.java
@@ -1,0 +1,228 @@
+package com.swarmus.hivear;
+
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Bundle;
+
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbManager;
+import android.hardware.usb.UsbDeviceConnection;
+import android.text.method.ScrollingMovementMethod;
+import android.util.Log;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+
+import com.felhr.usbserial.UsbSerialDevice;
+import com.felhr.usbserial.UsbSerialInterface;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Iterator;
+
+public class DeviceActivity extends AppCompatActivity {
+    PendingIntent permissionIntent;
+    TextView deviceListingText;
+    TextView deviceSerialData;
+    TextView currentDevice;
+    UsbDevice device;
+    UsbManager manager;
+    UsbDeviceConnection connection;
+    UsbSerialDevice serial;
+    UsbReceiver usbReceiver;
+
+    private static final String TAG = MainActivity.class.getSimpleName();
+    private static final String ACTION_USE_PERMISSION = "com.swarmus.usbcomm.USB_PERMISSION";
+    private static final String NO_DEVICE_FOUND = "No device found";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_device);
+
+        deviceListingText = findViewById(R.id.deviceListingText);
+        deviceListingText.setMovementMethod(new ScrollingMovementMethod());
+        deviceSerialData = findViewById(R.id.deviceSerialData);
+        deviceSerialData.setMovementMethod(new ScrollingMovementMethod());
+        currentDevice = findViewById(R.id.currentDevice);
+        setNoDeviceInfo();
+
+        FloatingActionButton toCommandButton = findViewById(R.id.toCommandButton);
+        toCommandButton.setOnClickListener(view -> {
+            Intent goToCommand = new Intent(getApplicationContext(), MainActivity.class);
+            goToCommand.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+            startActivity(goToCommand);
+        });
+
+        Button clearDataButton = findViewById(R.id.clearSerialDataButton);
+        clearDataButton.setOnClickListener(v -> deviceSerialData.setText(""));
+
+        Button upButton = findViewById(R.id.upButton);
+        upButton.setOnClickListener(v -> {
+            if (serial != null) {
+                byte[] data = ("Up"+'\n').getBytes();
+                serial.write(data);
+            }
+        });
+        Button leftButton = findViewById(R.id.leftButton);
+        leftButton.setOnClickListener(v -> {
+            if (serial != null) {
+                byte[] data = ("Left"+'\n').getBytes();
+                serial.write(data);
+            }
+        });
+        Button rightButton = findViewById(R.id.rightButton);
+        rightButton.setOnClickListener(v -> {
+            if (serial != null) {
+                byte[] data = ("Right"+'\n').getBytes();
+                serial.write(data);
+            }
+        });
+        Button downButton = findViewById(R.id.downButton);
+        downButton.setOnClickListener(v -> {
+            if (serial != null) {
+                byte[] data = ("Down"+'\n').getBytes();
+                serial.write(data);
+            }
+        });
+        Button stopButton = findViewById(R.id.stopButton);
+        stopButton.setOnClickListener(v -> {
+            if (serial != null) {
+                byte[] data = ("Stop"+'\n').getBytes();
+                serial.write(data);
+            }
+        });
+
+        usbReceiver = new UsbReceiver(this);
+        IntentFilter usbDeviceFilter = new IntentFilter();
+        usbDeviceFilter.addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED);
+        usbDeviceFilter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
+        registerReceiver(usbReceiver, usbDeviceFilter);
+
+        // Load devices
+        manager = (UsbManager) getSystemService(Context.USB_SERVICE);
+        permissionIntent = PendingIntent.getBroadcast(this, 0, new Intent(
+                ACTION_USE_PERMISSION), 0);
+        IntentFilter filter = new IntentFilter(ACTION_USE_PERMISSION);
+        registerReceiver(usbReceiverPermission, filter);
+
+        newUsbConnection();
+    }
+
+    private void listenToSerial() {
+        if (device != null && manager != null) {
+            if (manager.hasPermission(device)) {
+                startSerialConnection(manager, device);
+            }
+            else {
+                Log.d("Serial", "Device doesn't have permissions");
+            }
+        }
+    }
+
+    private void stopListenToSerial() {
+        if (serial != null) {
+            stopSerialConnection(serial);
+        }
+    }
+
+    void startSerialConnection(UsbManager usbManager, UsbDevice device) {
+        connection = usbManager.openDevice(device);
+        serial = UsbSerialDevice.createUsbSerialDevice(device, connection);
+
+        if (serial != null && serial.open()) {
+            serial.setBaudRate(9600);
+            serial.setDataBits(UsbSerialInterface.DATA_BITS_8);
+            serial.setStopBits(UsbSerialInterface.STOP_BITS_1);
+            serial.setParity(UsbSerialInterface.PARITY_NONE);
+            serial.setFlowControl(UsbSerialInterface.FLOW_CONTROL_OFF);
+            serial.read(mCallback);
+        }
+    }
+
+    void stopSerialConnection(UsbSerialDevice serial) {
+        if (serial != null && serial.open()) {
+            serial.close();
+        }
+    }
+
+    public void write(byte[] data) {
+        if (serial != null)
+            serial.write(data);
+    }
+
+    UsbSerialInterface.UsbReadCallback mCallback = (data) -> {
+        String dataStr = new String(data, StandardCharsets.UTF_8);
+        if (deviceSerialData != null) {
+            deviceSerialData.append(dataStr);
+        }
+        Log.i(TAG, "Data received: " + dataStr);
+    };
+
+    public void newUsbConnection() {
+        HashMap<String, UsbDevice> deviceList = manager.getDeviceList();
+        Iterator<UsbDevice> deviceIterator = deviceList.values().iterator();
+        String i = "";
+        while(deviceIterator.hasNext()) {
+            device = deviceIterator.next();
+            manager.requestPermission(device, permissionIntent);
+            i += "\n" + "DeviceID: " + device.getDeviceId() + "\n"
+                    + "DeviceName: " + device.getDeviceName() + "\n"
+                    + "DeviceClass: " + device.getDeviceClass() + " - "
+                    + "DeviceSubClass: " + device.getDeviceSubclass() + "\n"
+                    + "VendorID: " + device.getVendorId() + "\n"
+                    + "ProductID: " + device.getProductId() + "\n"
+                    + "Protocol: " + device.getDeviceProtocol() + "\n";
+        }
+        deviceListingText.setText(i);
+        Log.d("INFO", "I: " + i);
+        if (device != null) {
+            deviceSerialData.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.design_default_color_on_primary));
+            currentDevice.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.design_default_color_on_primary));
+            currentDevice.setText(device.getProductName());
+            listenToSerial();
+        }
+        else {
+            setNoDeviceInfo();
+        }
+    }
+
+    public void endUsbConnection() {
+        stopListenToSerial();
+        setNoDeviceInfo();
+    }
+
+    private void setNoDeviceInfo() {
+        deviceListingText.setText("");
+        deviceSerialData.setText("");
+        currentDevice.setTextColor(ContextCompat.getColor(getApplicationContext(), R.color.wrong_entry));
+        currentDevice.setText(NO_DEVICE_FOUND);
+    }
+
+    private final BroadcastReceiver usbReceiverPermission = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+        String action = intent.getAction();
+        if (ACTION_USE_PERMISSION.equals(action)) {
+            synchronized (this) {
+                UsbDevice device = intent.getParcelableExtra(UsbManager.EXTRA_DEVICE);
+                if (intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)) {
+                    if (device != null) {
+                        // call method to set up device communication
+                    }
+                } else {
+                    Log.d("ERROR", "permission denied for device " + device);
+                }
+            }
+        }
+        }
+    };
+}

--- a/HiveAR/app/src/main/java/com/swarmus/hivear/MainActivity.java
+++ b/HiveAR/app/src/main/java/com/swarmus/hivear/MainActivity.java
@@ -19,15 +19,20 @@ public class MainActivity extends AppCompatActivity {
         Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
-        FloatingActionButton fab = findViewById(R.id.toARButton);
-        fab.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                Intent goToAR = new Intent(getApplicationContext(), ARActivity.class);
-                goToAR.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-                goToAR.addFlags(Intent.FLAG_ACTIVITY_NO_USER_ACTION);
-                startActivity(goToAR);
-            }
+        FloatingActionButton toARButton = findViewById(R.id.toARButton);
+        toARButton.setOnClickListener(view -> {
+            Intent goToAR = new Intent(getApplicationContext(), ARActivity.class);
+            goToAR.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+            goToAR.addFlags(Intent.FLAG_ACTIVITY_NO_USER_ACTION);
+            startActivity(goToAR);
+        });
+
+        FloatingActionButton toDevicesButton = findViewById(R.id.toDevicesButton);
+        toDevicesButton.setOnClickListener(view -> {
+            Intent gotoDevices = new Intent(getApplicationContext(), DeviceActivity.class);
+            gotoDevices.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+            gotoDevices.addFlags(Intent.FLAG_ACTIVITY_NO_USER_ACTION);
+            startActivity(gotoDevices);
         });
     }
 }

--- a/HiveAR/app/src/main/java/com/swarmus/hivear/UsbReceiver.java
+++ b/HiveAR/app/src/main/java/com/swarmus/hivear/UsbReceiver.java
@@ -1,0 +1,35 @@
+package com.swarmus.hivear;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.hardware.usb.UsbManager;
+import android.util.Log;
+
+public class UsbReceiver extends BroadcastReceiver {
+
+    private static final String logTag = "UsbReceiver";
+    private DeviceActivity deviceActivity;
+
+    public UsbReceiver() {
+        this.deviceActivity = null;
+    }
+
+    public UsbReceiver(DeviceActivity deviceActivity) {
+        this.deviceActivity = deviceActivity;
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String action = intent.getAction();
+        if (UsbManager.ACTION_USB_DEVICE_ATTACHED.equals(action)) {
+            Log.d(logTag, "USB device connected");
+            deviceActivity.newUsbConnection();
+        }
+        else if (UsbManager.ACTION_USB_DEVICE_DETACHED.equals(action)) {
+            Log.d(logTag, "USB device disconnected");
+            deviceActivity.endUsbConnection();
+        }
+    }
+}
+

--- a/HiveAR/app/src/main/res/layout/activity_device.xml
+++ b/HiveAR/app/src/main/res/layout/activity_device.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".DeviceActivity">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="409dp"
+        android:layout_height="641dp"
+        tools:layout_editor_absoluteX="1dp">
+
+        <TextView
+            android:id="@+id/connectedDevices"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="30dp"
+            android:layout_marginTop="15dp"
+            android:text="@string/connected_devices"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/deviceListingText"
+            android:layout_width="0dp"
+            android:layout_height="150dp"
+            android:layout_marginStart="30dp"
+            android:layout_marginEnd="30dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/connectedDevices" />
+
+        <TextView
+            android:id="@+id/serialDataTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="30dp"
+            android:layout_marginTop="15dp"
+            android:text="@string/serial_data"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/deviceListingText" />
+
+        <TextView
+            android:id="@+id/deviceSerialData"
+            android:layout_width="0dp"
+            android:layout_height="150dp"
+            android:layout_marginStart="30dp"
+            android:layout_marginEnd="30dp"
+            android:scrollbars="vertical"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.444"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/serialDataTitle" />
+
+        <TextView
+            android:id="@+id/currentDevice"
+            android:layout_width="0dp"
+            android:layout_height="21dp"
+            android:layout_marginStart="30dp"
+            android:layout_marginEnd="30dp"
+            app:layout_constraintBottom_toBottomOf="@+id/clearSerialDataButton"
+            app:layout_constraintEnd_toStartOf="@+id/clearSerialDataButton"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/clearSerialDataButton" />
+
+        <Button
+            android:id="@+id/clearSerialDataButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="15dp"
+            android:layout_marginEnd="30dp"
+            android:text="@string/clear"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/deviceSerialData" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginTop="15dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/clearSerialDataButton">
+
+            <Button
+                android:id="@+id/downButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.5"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/stopButton" />
+
+            <Button
+                android:id="@+id/rightButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toEndOf="@id/stopButton"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <Button
+                android:id="@+id/leftButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="20dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/stopButton"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <Button
+                android:id="@+id/stopButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.5"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <Button
+                android:id="@+id/upButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="20dp"
+                app:layout_constraintBottom_toTopOf="@+id/stopButton"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.5"
+                app:layout_constraintStart_toStartOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/toCommandButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|start"
+        android:layout_margin="@dimen/fab_margin"
+        android:contentDescription="@string/send_to_command_view"
+        app:srcCompat="@android:drawable/stat_notify_chat" />
+
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/HiveAR/app/src/main/res/layout/activity_main.xml
+++ b/HiveAR/app/src/main/res/layout/activity_main.xml
@@ -6,6 +6,15 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/toDevicesButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:layout_margin="@dimen/fab_margin"
+        android:contentDescription="@string/switch_to_ar_view_layout"
+        app:srcCompat="@android:drawable/stat_notify_sdcard" />
+
     <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/HiveAR/app/src/main/res/values/colors.xml
+++ b/HiveAR/app/src/main/res/values/colors.xml
@@ -7,4 +7,5 @@
     <color name="brown_dark">#6B4701</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="wrong_entry">#FF0000</color>
 </resources>

--- a/HiveAR/app/src/main/res/values/strings.xml
+++ b/HiveAR/app/src/main/res/values/strings.xml
@@ -8,4 +8,7 @@
     <string name="settings">Settings</string>
     <string name="send_to_command_view">Send to Command View</string>
     <string name="switch_to_ar_view_layout">Switch to AR view layout</string>
+    <string name="clear">Clear</string>
+    <string name="connected_devices">Connected Devices</string>
+    <string name="serial_data">Serial Data</string>
 </resources>

--- a/HiveAR/app/src/main/res/xml/device_filter.xml
+++ b/HiveAR/app/src/main/res/xml/device_filter.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <usb-device vendor-id="11012" product-id="49164" class="239" subclass="2" />
+    <usb-device vendor-id="3034" product-id="33107" class="0" subclass="0" />
+</resources>

--- a/HiveAR/build.gradle
+++ b/HiveAR/build.gradle
@@ -16,6 +16,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven { url "https://jitpack.io" }
     }
 }
 


### PR DESCRIPTION
Right now, app can list usb devices connected to the android smartphone and listen to serial data on the last usb device if possible.
Also, there are 5 sample command buttons to test serial communication with: up, down, left, right and stop. 
 
The debug layout looks like such:
![image](https://user-images.githubusercontent.com/34560270/104982169-154b5a80-59d8-11eb-94e2-13a5cd8b0303.png)
