### PR TITLE
Add protobuf task to generate java code from proto files.

### DIFF
--- a/HiveAR/app/build.gradle
+++ b/HiveAR/app/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }
 
-// Dépendances faites par https://nimblehq.co/public/downloads/android-bangkok-conference-2020-protobuf-android-nimble.pdf
+// Dependancies from https://nimblehq.co/public/downloads/android-bangkok-conference-2020-protobuf-android-nimble.pdf
 protobuf {
     protoc {
         artifact = "com.google.protobuf:protoc:3.14.0"

--- a/HiveAR/app/build.gradle
+++ b/HiveAR/app/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.android.application'
+    id "com.google.protobuf" version "0.8.14"
 }
 
 android {
@@ -35,7 +36,25 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'com.github.felHR85:UsbSerial:6.1.0'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
+    implementation 'com.google.protobuf:protobuf-javalite:3.14.0'
     testImplementation 'junit:junit:4.13.1'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+}
+
+// Dépendances faites par https://nimblehq.co/public/downloads/android-bangkok-conference-2020-protobuf-android-nimble.pdf
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:3.14.0"
+    }
+
+    generateProtoTasks {
+        all().each { task ->
+            task.builtins {
+                java {
+                    option 'lite'
+                }
+            }
+        }
+    }
 }

--- a/HiveAR/gradle/wrapper/gradle-wrapper.properties
+++ b/HiveAR/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jan 13 17:25:56 EST 2021
+#Sun Jan 31 09:38:11 EST 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
Generate java classes from proto files under folder: "HiveAR/app/src/main/proto".

It is using protobuf-javalite as it is mentionned to get better performance when using on Android. (smaller code size)

Graddle-wrapper.properties changes are a small improvement for building in Android studio, but is not directly linked to protobuf.