### PR TITLE
Added negative argument key and remove editable text for ip address

### DIFF
--- a/HiveAR/app/src/main/java/com/swarmus/hivear/adapters/CommandsAdapter.java
+++ b/HiveAR/app/src/main/java/com/swarmus/hivear/adapters/CommandsAdapter.java
@@ -126,9 +126,9 @@ public class CommandsAdapter extends RecyclerView.Adapter<CommandsAdapter.Comman
             EditText argInput = argViewBinding.getRoot().findViewById(R.id.command_argument_value);
 
             if (arg.getArgumentType().equals(Integer.class)) {
-                argInput.setInputType(InputType.TYPE_CLASS_NUMBER);
+                argInput.setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_SIGNED);
             } else if (arg.getArgumentType().equals(Float.class)) {
-                argInput.setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL);
+                argInput.setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL | InputType.TYPE_NUMBER_FLAG_SIGNED);
             } else {
                 continue;
             }

--- a/HiveAR/app/src/main/java/com/swarmus/hivear/fragments/TcpSettingsFragment.java
+++ b/HiveAR/app/src/main/java/com/swarmus/hivear/fragments/TcpSettingsFragment.java
@@ -7,6 +7,7 @@ import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.TextView;
 
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
@@ -33,52 +34,10 @@ public class TcpSettingsFragment extends Fragment {
         View view = inflater.inflate(R.layout.fragment_tcp_settings, container, false);
 
         tcpSettingsViewModel = new ViewModelProvider(requireActivity(), new ViewModelProvider.NewInstanceFactory()).get(TcpSettingsViewModel.class);
-        TextInputEditText ipInputEditText = view.findViewById(R.id.IPTextInputEditText);
+        TextView ipText = view.findViewById(R.id.IPText);
 
-        if (ipInputEditText != null) {
-            // IP text input filtering
-            InputFilter[] filters = new InputFilter[1];
-            filters[0] = (source, start, end, dest, dstart, dend) -> {
-                if (end > start) {
-                    String destTxt = dest.toString();
-                    String resultingTxt = destTxt.substring(0, dstart)
-                            + source.subSequence(start, end)
-                            + destTxt.substring(dend);
-                    if (!resultingTxt
-                            .matches("^\\d{1,3}(\\.(\\d{1,3}(\\.(\\d{1,3}(\\.(\\d{1,3})?)?)?)?)?)?")) {
-                        return "";
-                    } else {
-                        String[] splits = resultingTxt.split("\\.");
-                        for (String split : splits) {
-                            if (Integer.parseInt(split) > 255) {
-                                return "";
-                            }
-                        }
-                    }
-                }
-                return null;
-            };
-            ipInputEditText.setFilters(filters);
-
-            ipInputEditText.setText(ip);
-
-            ipInputEditText.addTextChangedListener(new TextWatcher() {
-                @Override
-                public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {}
-
-                @Override
-                public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {}
-
-                @Override
-                public void afterTextChanged(Editable editable) {
-                    tcpSettingsViewModel.setIpAddress(
-                            Objects.requireNonNull(ipInputEditText.getText()).toString());
-                }
-            });
-
-            ipInputEditText.setOnFocusChangeListener((view1, b) -> {
-                if (b) {ipInputEditText.setSelection(ipInputEditText.getText().length());}
-            });
+        if (ipText != null) {
+            ipText.setText(ip);
         }
 
         TextInputEditText portInputEditText = view.findViewById(R.id.PortTextInputEditText);

--- a/HiveAR/app/src/main/res/layout/fragment_tcp_settings.xml
+++ b/HiveAR/app/src/main/res/layout/fragment_tcp_settings.xml
@@ -12,30 +12,19 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/IPTextInputLayout"
+        <TextView
+            android:id="@+id/IPText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/IPTextInputEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/ip_address"
-                android:inputType="number|numberDecimal"
-                android:digits="0123456789."
-                android:imeOptions="actionNext"
-                android:autofillHints="XXX.XXX.XXX.XXX"/>
-        </com.google.android.material.textfield.TextInputLayout>
+            app:layout_constraintTop_toTopOf="parent"/>
 
         <com.google.android.material.textfield.TextInputLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/IPTextInputLayout">
+            app:layout_constraintTop_toBottomOf="@+id/IPText">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/PortTextInputEditText"


### PR DESCRIPTION
- In functions of agents, arguments can be negative. To do so, the ".-" key most be toggled once or twice if a dot was inserted instead
- IP address is now not editable as the cellphone is considered a server now