### PR TITLE
changed function arguments to be align from center

### DIFF
--- a/HiveAR/app/src/main/res/layout/command_argument.xml
+++ b/HiveAR/app/src/main/res/layout/command_argument.xml
@@ -29,7 +29,7 @@
             android:text="@={function_arg.value}"
             android:textSize="16sp"
             android:importantForAutofill="no"
-            android:textAlignment="textEnd"/>
+            android:textAlignment="center"/>
 
     </LinearLayout>
 </layout>


### PR DESCRIPTION
It was difficult to edit text when aligned to the end of the screen. Instead, text is centered in edit text box