### PR TITLE
Change camera+google play store permissions requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ It is also able to send command to this swarm and to observe informations in rea
 
 * `Android Studio 4.1+` to open android project with gradle dependencies.
 * Android smartphone or emulator. (emulator has some limitation linked to serial communication)
+* 'ARCore' installed from Google Play Store to use AR features.
 
 ## Building 
 First, clone the repo with command:


### PR DESCRIPTION
Never goes to Google Play Store page, instead: log to the user the reason AR won't be supported
Better camera permission prompt: don't change to settings activity, small prompt instead